### PR TITLE
fix(notification): surround with try/catch to avoid error with specif…

### DIFF
--- a/angular-notification.js
+++ b/angular-notification.js
@@ -52,8 +52,11 @@ function $notificationProvider() {
         }, provider.options || {}, options);
 
         // Create a base notification.
+        try {
         self.baseNotification = new $window.Notification(title, options);
-
+        } catch (error) {
+          return;
+        }
         // Close notification after specified delay.
         if (options.delay) setTimeout(angular.bind(self, self.close), options.delay);
 


### PR DESCRIPTION
…ic browser

Since Chrome 42 on Android (for example), the Notification API is present but can't be used directly.
We have to use serviceWorker to push notification to client instead of the simple window.Notification API. So, we have to catch the potential error and return nothing if an error occurs.
If you have a better idea of implementation, let me know.
